### PR TITLE
fixed fields limitations

### DIFF
--- a/FPDFS/forms.py
+++ b/FPDFS/forms.py
@@ -29,20 +29,16 @@ class documentomixin(forms.ModelForm):
     
         
     N_documento= forms.CharField(required=True, label="Número del documento", 
-                              min_length=6, 
-                              max_length=20,
+                              min_length=5, 
+                              max_length=5,
                               validators=[RegexValidator(regex=r'^[\w.@ +-]+$', 
                                                          message=(u"Carácter no valido. solo se permite caracteres de A-Z")
                                                          )],
                               widget=forms.TextInput(attrs={'placeholder': 'Agregue un número del documento'}))
         
         
-    descripcion_documento=forms.CharField(label="Descripción del documento",
-                                          validators=[RegexValidator(regex=r'^[\w.@ +-]+$', 
-                                                         message=(u"Carácter no valido. solo se permite caracteres de A-Z")
-                                                         )],
-                                          
-                                          widget=forms.Textarea(attrs={"required": False,}))
+    descripcion_documento=forms.CharField(required=False, label="Descripción del documento",
+                                          widget=forms.Textarea(attrs={'placeholder': 'Agregue una descripción del documento', 'rows': 3, 'cols': 20})),
 
     documento_pdf=forms.FileField(   
         widget=forms.FileInput(attrs={'accept':'application/pdf', type:"file" }),

--- a/FPDFS/models.py
+++ b/FPDFS/models.py
@@ -77,9 +77,13 @@ class pdfEnviadosGerente(TimestampMixin):
     """ 
     
     
-    nombre_documento =  models.CharField(max_length=22, verbose_name="Nombre del documento",  null=True)
-    N_documento =  models.CharField(max_length=22, verbose_name="Numero del documento", null=True) 
-    descripcion_documento= models.CharField(max_length=460,blank=True, null=True, verbose_name="Descripción del documento" )
+    nombre_documento = models.TextField(verbose_name="Nombre del documento", null=True)
+    N_documento = models.CharField(
+        max_length=5,
+        verbose_name="Numero del documento", 
+        null=True, 
+    )
+    descripcion_documento= models.TextField(blank=True, null=True, verbose_name="Descripción del documento" )
    
     usuario = models.ForeignKey(UsuariosTrime, on_delete = models.CASCADE)
     documento_pdf = models.FileField(upload_to=change_name, validators=[validate_file_extension, file_size],  verbose_name="Requisición")


### PR DESCRIPTION
- Quitar limitaciones de campos al cargar los documentos
- Nombre del documento no debe de tener máximo
- Número de documento debe de tener mínimo 5(para las requisiciones y solicitudes) caracteres no 6 (número que se va a asociar con la base de datos), para las ordenes mínimo 10(número que se va a asociar con la base de datos).
- Descripción del documento no debe ser obligatoria sino opcional.